### PR TITLE
Allow HTML code in the calendar title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1940,6 +1940,16 @@ function (date) {
 </tr>
 </table>
 
+The callback function can return HTML markup. If you want to use HTML entities in the title, you must use the callback function:
+
+```js
+function (date) {
+  let month = date.toLocaleDateString('en-US', { month: 'long' })
+  let year = date.toLocaleDateString('en-US', { year: 'numeric' })
+  return `<span class="month">${month}</span> <span class="year">${year}</span>`
+}
+```
+
 ### unselect
 - Type `function`
 - Default `undefined`

--- a/packages/core/src/Buttons.svelte
+++ b/packages/core/src/Buttons.svelte
@@ -27,7 +27,7 @@
 
 {#each buttons as button}
     {#if button == 'title'}
-        <h2 class="{$theme.title}">{$_viewTitle}</h2>
+        <h2 class="{$theme.title}">{@html $_viewTitle}</h2>
     {:else if button == 'prev'}
         <button class="{$theme.button} ec-{button}" aria-label={$buttonText.prev} on:click={prev}><i class="{$theme.icon} ec-{button}"></i></button>
     {:else if button == 'next'}


### PR DESCRIPTION
By allowing HTML in the calendar title, styling becomes much easier (e.g. year displayed in bold while the month is displayed using the regular weight).