### PR TITLE
Custom header buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Inspired by [FullCalendar](https://fullcalendar.io/), implements similar options
   - [firstDay](#firstday)
   - [flexibleSlotTimeLimits](#flexibleslottimelimits)
   - [headerToolbar](#headertoolbar)
+  - [customButtons](#customButtons)
   - [height](#height)
   - [hiddenDays](#hiddendays)
   - [highlightedDates](#highlighteddates)
@@ -1531,6 +1532,49 @@ An object can be supplied with properties `start`,`center`,`end`. These properti
 _a view name like_ `dayGridMonth`
 </td>
 <td>A button that will switch the calendar to a specific view</td>
+</tr>
+</table>
+
+### customButtons
+- Type `object`
+- Default `undefined`
+
+Defines custom buttons that can be used in the headerToolbar/footerToolbar.
+
+Specify a hash of custom buttons. Then reference them from the headerToolbar setting. Like this:
+
+```js
+let options = {
+  headerToolbar: {
+      start: 'prev,next today myCustomButton',
+      center: 'title',
+      end: `dayGridMonth,timeGridWeek,timeGridDay`
+  },
+  customButtons: {
+      myCustomButton: {
+          text: 'custom!',
+          click: function() {
+              alert('clicked the custom button!');
+          }
+      }
+  }
+};
+```
+Each customButton entry accepts the following properties:
+<table>
+<tr>
+<td>
+
+`text `
+</td>
+<td>The text to be display on the button itself</td>
+</tr>
+<tr>
+<td>
+
+`click`
+</td>
+<td>A callback function that is called when the button is clicked. Accepts one argument: ( <a href="https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent">mouseEvent</a> )</td>
 </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -1539,7 +1539,7 @@ _a view name like_ `dayGridMonth`
 - Type `object`
 - Default `undefined`
 
-Defines custom buttons that can be used in the headerToolbar/footerToolbar.
+Defines custom buttons that can be used in the headerToolbar.
 
 Specify a hash of custom buttons. Then reference them from the headerToolbar setting. Like this:
 

--- a/packages/core/src/Buttons.svelte
+++ b/packages/core/src/Buttons.svelte
@@ -4,7 +4,7 @@
 
     export let buttons;
 
-    let {_currentRange, _viewTitle, buttonText, date, duration, hiddenDays, theme, view} = getContext('state');
+    let {_currentRange, _viewTitle, buttonText, customButtons, date, duration, hiddenDays, theme, view} = getContext('state');
 
     let today = setMidnight(createDate()), isToday;
 
@@ -49,6 +49,11 @@
             on:click={() => $date = cloneDate(today)}
             disabled={isToday}
         >{$buttonText[button]}</button>
+    {:else if $customButtons[button] != null}
+        <button
+            class="{$theme.button} ec-{button}"
+            on:click={$customButtons[button].click}
+        >{$customButtons[button].text }</button>
     {:else if button != ''}
         <button
             class="{$theme.button}{$view === button ? ' ' + $theme.active : ''} ec-{button}"

--- a/packages/core/src/storage/options.js
+++ b/packages/core/src/storage/options.js
@@ -42,6 +42,7 @@ export function createOptions(plugins) {
             center: '',
             end: 'today prev,next'
         },
+        customButtons: undefined,
         height: undefined,
         hiddenDays: [],
         highlightedDates: [],  // ec option

--- a/packages/day-grid/README.md
+++ b/packages/day-grid/README.md
@@ -64,6 +64,7 @@ Inspired by [FullCalendar](https://fullcalendar.io/), implements similar options
   - [firstDay](#firstday)
   - [flexibleSlotTimeLimits](#flexibleslottimelimits)
   - [headerToolbar](#headertoolbar)
+  - [customButtons](#customButtons)
   - [height](#height)
   - [hiddenDays](#hiddendays)
   - [highlightedDates](#highlighteddates)
@@ -1531,6 +1532,49 @@ An object can be supplied with properties `start`,`center`,`end`. These properti
 _a view name like_ `dayGridMonth`
 </td>
 <td>A button that will switch the calendar to a specific view</td>
+</tr>
+</table>
+
+### customButtons
+- Type `object`
+- Default `undefined`
+
+Defines custom buttons that can be used in the headerToolbar/footerToolbar.
+
+Specify a hash of custom buttons. Then reference them from the headerToolbar setting. Like this:
+
+```js
+let options = {
+  headerToolbar: {
+      start: 'prev,next today myCustomButton',
+      center: 'title',
+      end: `dayGridMonth,timeGridWeek,timeGridDay`
+  },
+  customButtons: {
+      myCustomButton: {
+          text: 'custom!',
+          click: function() {
+              alert('clicked the custom button!');
+          }
+      }
+  }
+};
+```
+Each customButton entry accepts the following properties:
+<table>
+<tr>
+<td>
+
+`text `
+</td>
+<td>The text to be display on the button itself</td>
+</tr>
+<tr>
+<td>
+
+`click`
+</td>
+<td>A callback function that is called when the button is clicked. Accepts one argument: ( <a href="https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent">mouseEvent</a> )</td>
 </tr>
 </table>
 

--- a/packages/day-grid/README.md
+++ b/packages/day-grid/README.md
@@ -1539,7 +1539,7 @@ _a view name like_ `dayGridMonth`
 - Type `object`
 - Default `undefined`
 
-Defines custom buttons that can be used in the headerToolbar/footerToolbar.
+Defines custom buttons that can be used in the headerToolbar.
 
 Specify a hash of custom buttons. Then reference them from the headerToolbar setting. Like this:
 

--- a/packages/interaction/README.md
+++ b/packages/interaction/README.md
@@ -64,6 +64,7 @@ Inspired by [FullCalendar](https://fullcalendar.io/), implements similar options
   - [firstDay](#firstday)
   - [flexibleSlotTimeLimits](#flexibleslottimelimits)
   - [headerToolbar](#headertoolbar)
+  - [customButtons](#customButtons)
   - [height](#height)
   - [hiddenDays](#hiddendays)
   - [highlightedDates](#highlighteddates)
@@ -1531,6 +1532,49 @@ An object can be supplied with properties `start`,`center`,`end`. These properti
 _a view name like_ `dayGridMonth`
 </td>
 <td>A button that will switch the calendar to a specific view</td>
+</tr>
+</table>
+
+### customButtons
+- Type `object`
+- Default `undefined`
+
+Defines custom buttons that can be used in the headerToolbar/footerToolbar.
+
+Specify a hash of custom buttons. Then reference them from the headerToolbar setting. Like this:
+
+```js
+let options = {
+  headerToolbar: {
+      start: 'prev,next today myCustomButton',
+      center: 'title',
+      end: `dayGridMonth,timeGridWeek,timeGridDay`
+  },
+  customButtons: {
+      myCustomButton: {
+          text: 'custom!',
+          click: function() {
+              alert('clicked the custom button!');
+          }
+      }
+  }
+};
+```
+Each customButton entry accepts the following properties:
+<table>
+<tr>
+<td>
+
+`text `
+</td>
+<td>The text to be display on the button itself</td>
+</tr>
+<tr>
+<td>
+
+`click`
+</td>
+<td>A callback function that is called when the button is clicked. Accepts one argument: ( <a href="https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent">mouseEvent</a> )</td>
 </tr>
 </table>
 

--- a/packages/interaction/README.md
+++ b/packages/interaction/README.md
@@ -1539,7 +1539,7 @@ _a view name like_ `dayGridMonth`
 - Type `object`
 - Default `undefined`
 
-Defines custom buttons that can be used in the headerToolbar/footerToolbar.
+Defines custom buttons that can be used in the headerToolbar.
 
 Specify a hash of custom buttons. Then reference them from the headerToolbar setting. Like this:
 

--- a/packages/list/README.md
+++ b/packages/list/README.md
@@ -64,6 +64,7 @@ Inspired by [FullCalendar](https://fullcalendar.io/), implements similar options
   - [firstDay](#firstday)
   - [flexibleSlotTimeLimits](#flexibleslottimelimits)
   - [headerToolbar](#headertoolbar)
+  - [customButtons](#customButtons)
   - [height](#height)
   - [hiddenDays](#hiddendays)
   - [highlightedDates](#highlighteddates)
@@ -1531,6 +1532,49 @@ An object can be supplied with properties `start`,`center`,`end`. These properti
 _a view name like_ `dayGridMonth`
 </td>
 <td>A button that will switch the calendar to a specific view</td>
+</tr>
+</table>
+
+### customButtons
+- Type `object`
+- Default `undefined`
+
+Defines custom buttons that can be used in the headerToolbar/footerToolbar.
+
+Specify a hash of custom buttons. Then reference them from the headerToolbar setting. Like this:
+
+```js
+let options = {
+  headerToolbar: {
+      start: 'prev,next today myCustomButton',
+      center: 'title',
+      end: `dayGridMonth,timeGridWeek,timeGridDay`
+  },
+  customButtons: {
+      myCustomButton: {
+          text: 'custom!',
+          click: function() {
+              alert('clicked the custom button!');
+          }
+      }
+  }
+};
+```
+Each customButton entry accepts the following properties:
+<table>
+<tr>
+<td>
+
+`text `
+</td>
+<td>The text to be display on the button itself</td>
+</tr>
+<tr>
+<td>
+
+`click`
+</td>
+<td>A callback function that is called when the button is clicked. Accepts one argument: ( <a href="https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent">mouseEvent</a> )</td>
 </tr>
 </table>
 

--- a/packages/list/README.md
+++ b/packages/list/README.md
@@ -1539,7 +1539,7 @@ _a view name like_ `dayGridMonth`
 - Type `object`
 - Default `undefined`
 
-Defines custom buttons that can be used in the headerToolbar/footerToolbar.
+Defines custom buttons that can be used in the headerToolbar.
 
 Specify a hash of custom buttons. Then reference them from the headerToolbar setting. Like this:
 

--- a/packages/resource-time-grid/README.md
+++ b/packages/resource-time-grid/README.md
@@ -64,6 +64,7 @@ Inspired by [FullCalendar](https://fullcalendar.io/), implements similar options
   - [firstDay](#firstday)
   - [flexibleSlotTimeLimits](#flexibleslottimelimits)
   - [headerToolbar](#headertoolbar)
+  - [customButtons](#customButtons)
   - [height](#height)
   - [hiddenDays](#hiddendays)
   - [highlightedDates](#highlighteddates)
@@ -1531,6 +1532,49 @@ An object can be supplied with properties `start`,`center`,`end`. These properti
 _a view name like_ `dayGridMonth`
 </td>
 <td>A button that will switch the calendar to a specific view</td>
+</tr>
+</table>
+
+### customButtons
+- Type `object`
+- Default `undefined`
+
+Defines custom buttons that can be used in the headerToolbar/footerToolbar.
+
+Specify a hash of custom buttons. Then reference them from the headerToolbar setting. Like this:
+
+```js
+let options = {
+  headerToolbar: {
+      start: 'prev,next today myCustomButton',
+      center: 'title',
+      end: `dayGridMonth,timeGridWeek,timeGridDay`
+  },
+  customButtons: {
+      myCustomButton: {
+          text: 'custom!',
+          click: function() {
+              alert('clicked the custom button!');
+          }
+      }
+  }
+};
+```
+Each customButton entry accepts the following properties:
+<table>
+<tr>
+<td>
+
+`text `
+</td>
+<td>The text to be display on the button itself</td>
+</tr>
+<tr>
+<td>
+
+`click`
+</td>
+<td>A callback function that is called when the button is clicked. Accepts one argument: ( <a href="https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent">mouseEvent</a> )</td>
 </tr>
 </table>
 

--- a/packages/resource-time-grid/README.md
+++ b/packages/resource-time-grid/README.md
@@ -1539,7 +1539,7 @@ _a view name like_ `dayGridMonth`
 - Type `object`
 - Default `undefined`
 
-Defines custom buttons that can be used in the headerToolbar/footerToolbar.
+Defines custom buttons that can be used in the headerToolbar.
 
 Specify a hash of custom buttons. Then reference them from the headerToolbar setting. Like this:
 

--- a/packages/time-grid/README.md
+++ b/packages/time-grid/README.md
@@ -64,6 +64,7 @@ Inspired by [FullCalendar](https://fullcalendar.io/), implements similar options
   - [firstDay](#firstday)
   - [flexibleSlotTimeLimits](#flexibleslottimelimits)
   - [headerToolbar](#headertoolbar)
+  - [customButtons](#customButtons)
   - [height](#height)
   - [hiddenDays](#hiddendays)
   - [highlightedDates](#highlighteddates)
@@ -1531,6 +1532,49 @@ An object can be supplied with properties `start`,`center`,`end`. These properti
 _a view name like_ `dayGridMonth`
 </td>
 <td>A button that will switch the calendar to a specific view</td>
+</tr>
+</table>
+
+### customButtons
+- Type `object`
+- Default `undefined`
+
+Defines custom buttons that can be used in the headerToolbar/footerToolbar.
+
+Specify a hash of custom buttons. Then reference them from the headerToolbar setting. Like this:
+
+```js
+let options = {
+  headerToolbar: {
+      start: 'prev,next today myCustomButton',
+      center: 'title',
+      end: `dayGridMonth,timeGridWeek,timeGridDay`
+  },
+  customButtons: {
+      myCustomButton: {
+          text: 'custom!',
+          click: function() {
+              alert('clicked the custom button!');
+          }
+      }
+  }
+};
+```
+Each customButton entry accepts the following properties:
+<table>
+<tr>
+<td>
+
+`text `
+</td>
+<td>The text to be display on the button itself</td>
+</tr>
+<tr>
+<td>
+
+`click`
+</td>
+<td>A callback function that is called when the button is clicked. Accepts one argument: ( <a href="https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent">mouseEvent</a> )</td>
 </tr>
 </table>
 

--- a/packages/time-grid/README.md
+++ b/packages/time-grid/README.md
@@ -1539,7 +1539,7 @@ _a view name like_ `dayGridMonth`
 - Type `object`
 - Default `undefined`
 
-Defines custom buttons that can be used in the headerToolbar/footerToolbar.
+Defines custom buttons that can be used in the headerToolbar.
 
 Specify a hash of custom buttons. Then reference them from the headerToolbar setting. Like this:
 


### PR DESCRIPTION
- Support custom buttons in header toolbar

Partially solves #159  

The support is rudimentary thus far, with only `text` and `click` options with no option to pass in custom HTML. However, I really dislike passing in raw HTML as options and would rather pass it in as a slot instead. What do you think?