### PR TITLE
Add typescript dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,8 @@
         "rollup-plugin-scss": "^4.0.0",
         "rollup-plugin-svelte": "^7.2.2",
         "sass": "^1.81.0",
-        "svelte": "^4.2.19"
+        "svelte": "^4.2.19",
+        "typescript": "^5.7.2"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -4397,6 +4398,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
+      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "rollup-plugin-scss": "^4.0.0",
     "rollup-plugin-svelte": "^7.2.2",
     "sass": "^1.81.0",
-    "svelte": "^4.2.19"
+    "svelte": "^4.2.19",
+    "typescript": "^5.7.2"
   },
   "dependencies": {
     "sirv-cli": "^2.0.2"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,33 @@
+{
+	"include": [
+		"./packages/core/**/*",
+		"./packages/day-grid/**/*",
+		"./packages/interaction/**/*",
+		"./packages/list/**/*",
+		"./packages/resource-time-grid/**/*",
+		"./packages/resource-timeline/**/*",
+		"./packages/time-grid/**/*",
+	],
+	"compilerOptions": {
+        "outDir": "./ts",
+		"allowJs": true,
+		"checkJs": true,
+		"strict": true,
+		"target": "ES6",
+		"module": "NodeNext",
+		"moduleResolution": "NodeNext",
+		"alwaysStrict": true,
+		"strictNullChecks": true,
+		"noImplicitReturns": true,
+		"noUnusedLocals": true,
+		"allowUnreachableCode": false,
+		"noUncheckedIndexedAccess": true,
+		"declaration": true,
+		"isolatedModules": true,
+		"sourceMap": true,
+        "noImplicitAny": false,
+		//"rewriteRelativeImportExtensions": true,
+
+		"lib": ["ESNext", "dom"],
+	},
+}


### PR DESCRIPTION
I'd like to suggest adding Typescript to the project as I believe there are multiple benefits compared to relying on a separate [@types](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/event-calendar__core/) repo. With Typescript built in, project development would benefit for real-time error detection, guaranteed type accuracy and, eventually, eliminate the need for a separate types repo.