### PR TITLE
Add localStorage-based state persistence for expanders

### DIFF
--- a/packages/resource-timeline/src/Expander.svelte
+++ b/packages/resource-timeline/src/Expander.svelte
@@ -8,12 +8,26 @@
 
     let payload = {};
 
-    $: payload = getPayload(resource);
+    $: {
+        payload = getPayload(resource);
+        const storageKey = `expanded-${resource.title}`;
+        if (localStorage.getItem(storageKey) === 'true') {
+            payload.expanded = true;
+        } else {
+            payload.expanded = false;
+        }
+        toggle(payload.children, payload.expanded);
+    }
 
     function handleClick() {
         payload.expanded = !payload.expanded;
         toggle(payload.children, payload.expanded);
         resources.update(identity);
+
+        if (resource.id === 'undefined') {
+            const storageKey = `expanded-${resource.title}`;
+            localStorage.setItem(storageKey, payload.expanded);
+        }
     }
 
     function toggle(children, expand) {


### PR DESCRIPTION
A simple fix to persist the state (expanded/collapsed) of resource toggles using localStorage, keyed by the resource title.