### PR TITLE
Add localStorage-based state persistence for expanders

### DIFF
--- a/packages/resource-timeline/src/Expander.svelte
+++ b/packages/resource-timeline/src/Expander.svelte
@@ -11,11 +11,13 @@
     $: {
         payload = getPayload(resource);
         const storageKey = `expanded-${resource.title}`;
-        if (localStorage.getItem(storageKey) === 'true') {
+
+        if (localStorage.getItem(storageKey) === null) {
             payload.expanded = true;
         } else {
-            payload.expanded = false;
+            payload.expanded = localStorage.getItem(storageKey) === 'true';
         }
+        
         toggle(payload.children, payload.expanded);
     }
 


### PR DESCRIPTION
A simple fix to persist the state (expanded/collapsed) of resource toggles using localStorage, keyed by the resource title