### PR TITLE
adds allowMultidayResize option as a way to turn off resizing across days

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Inspired by [FullCalendar](https://fullcalendar.io/), implements similar options
 
   - [allDayContent](#alldaycontent)
   - [allDaySlot](#alldayslot)
+  - [allowMutlidayResize](#allowmutlidayresize)
   - [buttonText](#buttontext)
   - [customButtons](#custombuttons)
   - [date](#date)
@@ -294,6 +295,14 @@ The default text
 Determines whether the `all-day` slot is displayed at the top of the calendar.
 
 When hidden with `false`, all-day events will not be displayed in `timeGrid`/`resourceTimeGrid` views.
+
+### allowMutlidayResize
+- Type `boolean`
+- Default `true`
+
+Determines whether an event can by resized across multiple days.
+
+When set to `false` resizing an event will be limited to a single day.
 
 ### buttonText
 - Type `object` or `function`

--- a/packages/interaction/src/Action.svelte
+++ b/packages/interaction/src/Action.svelte
@@ -7,8 +7,8 @@
     } from '@event-calendar/core';
     import {animate, limit} from './utils';
 
-    let {_iEvents, _iClass, _events, _view, _dayGrid, _draggable, _bodyEl, dateClick, dragScroll, datesAboveResources,
-        eventDragMinDistance, eventDragStart, eventDragStop, eventDrop, eventLongPressDelay,
+    let {_iEvents, _iClass, _events, _view, _dayGrid, _draggable, _bodyEl, allowMutlidayResize, dateClick, dragScroll,
+        datesAboveResources, eventDragMinDistance, eventDragStart, eventDragStop, eventDrop, eventLongPressDelay,
         eventResizeStart, eventResizeStop, eventResize, longPressDelay, selectable, select: selectFn,
         selectBackgroundColor, selectLongPressDelay, selectMinDistance, slotDuration, slotHeight, slotWidth, unselect: unselectFn,
         unselectAuto, unselectCancel, validRange, view} = getContext('state');
@@ -270,7 +270,10 @@
 
     function handlePointerMove(jsEvent) {
         if (complexAction() && jsEvent.isPrimary) {
-            toX = jsEvent.clientX;
+            // Ignore the change in x if multiday resize is disabled
+            if (!resizing() || $allowMutlidayResize) {
+                toX = jsEvent.clientX;
+            }
             toY = jsEvent.clientY;
             move(jsEvent);
         }

--- a/packages/interaction/src/index.js
+++ b/packages/interaction/src/index.js
@@ -4,6 +4,7 @@ import Auxiliary from './Auxiliary.svelte';
 
 export default {
     createOptions(options) {
+        options.allowMutlidayResize = true;
         options.dateClick = undefined;
         options.dragScroll = true;
         options.editable = false;


### PR DESCRIPTION
Closes #412 

This PR adds a `allowMultidayResize` option that defaults to `true` which maintains the existing library functionality. When `allowMultidayResize` is set to false, the user will be unable to drag an event across multiple days when resizing.

This option does not affect the users ability to drag an event to different days. It also does not affect the ability to drag an event to the end/start of a day and have it flow onto the next/previous day. The option only applies during a resize action.

@vkurko Let me know if you have any questions, or if you would like to see any adjustments. Thanks!
