### PR TITLE
Adding a Dockerfile to allow compilation of the bundled library through Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+# Use with:  docker build  --pull --rm -f 'Dockerfile' '.' --output './dist'
+
+# COMPILE SVELTE AS JS LIB WITH A NODE DOCKER IMAGE
+FROM node:23-alpine AS build
+
+WORKDIR /app
+COPY . .
+RUN npm install
+RUN npm install @rollup/rollup-linux-x64-musl
+RUN npm run build
+
+# COPY ONLY THE BUNDLED LIB AND CSS
+FROM scratch
+COPY --from=build /app/packages/build/dist/* /


### PR DESCRIPTION
# Context 

Hi !

Thanks for your great work.

I needed to compile your code into a bundled JS (to test some customisation) but I wasn't able to find a documented way.

Through #344 and #59, I was able to process (even if you quitted rollup for vite during the 4.0.0 milestone).

I thought I would share with you and the community if someone else as the same need.

You just need the Dockerfile at the root of your repo and running it with Docker build.

# What the code do :
Docker pull a node image for the compilation, compile and export the JS and CSS bundled libraries in a dist/ directory

Kind regards,