### PR TITLE
Fix event styles not being applied

### DIFF
--- a/packages/core/src/lib/components/BaseEvent.svelte
+++ b/packages/core/src/lib/components/BaseEvent.svelte
@@ -1,7 +1,7 @@
 <script>
     import {getContext, onMount} from 'svelte';
     import {
-        bgEvent, createEventClasses, createEventContent, entries, helperEvent, identity, isFunction, keyEnter,
+        bgEvent, createEventClasses, createEventContent, entries, fromEntries, helperEvent, identity, isFunction, keyEnter,
         resourceBackgroundColor, resourceTextColor, setContent, toEventWithLocalDates, toViewWithLocalDates
     } from '#lib';
 
@@ -26,7 +26,7 @@
     let bgColor = $derived(event.backgroundColor ?? resourceBackgroundColor(event, $resources) ?? $eventBackgroundColor ?? $eventColor);
     let txtColor = $derived(event.textColor ?? resourceTextColor(event, $resources) ?? $eventTextColor);
     let style = $derived(entries(styles(
-        {'background-color': bgColor, 'color': txtColor}
+        {'background-color': bgColor, 'color': txtColor, ...fromEntries(event.styles.map(style => style.split(':')))}
     )).map(entry => `${entry[0]}:${entry[1]}`).join(';'));
 
     // Class

--- a/packages/core/src/lib/utils.js
+++ b/packages/core/src/lib/utils.js
@@ -10,6 +10,10 @@ export function entries(object) {
     return Object.entries(object);
 }
 
+export function fromEntries(array) {
+    return Object.fromEntries(array);
+}
+
 export function floor(value) {
     return Math.floor(value);
 }


### PR DESCRIPTION
When creating events, custom styles are not being applied, for example:

```
{
    start: days[0] + " 10:00",
    end: days[0] + " 14:00",
    resourceId: 1,
    title: "The calendar can display background and regular events",
    color: "#FE6B64",
    styles: ["font-size: 16px", "background-color: blue"]
}
```

