### PR TITLE
Fix events row height

### DIFF
--- a/packages/core/src/lib/resources.js
+++ b/packages/core/src/lib/resources.js
@@ -16,7 +16,8 @@ function _createResources(input, level, flat) {
             level,
             children: [],
             expanded: true,
-            hidden: false
+            hidden: false,
+            height: 0
         };
         setPayload(resource, payload);
         if (item.children) {

--- a/packages/core/src/plugins/resource-timeline/Days.svelte
+++ b/packages/core/src/plugins/resource-timeline/Days.svelte
@@ -2,7 +2,7 @@
     import {getContext} from 'svelte';
     import {
         addDay, addDuration, bgEvent, ceil, cloneDate, createEventChunk, DAY_IN_SECONDS, eventIntersects,
-        limitToRange, max, runReposition
+        getPayload, limitToRange, max, runReposition
     } from '#lib';
     import {getSlotTimeLimits, prepareEventChunks} from './lib.js';
     import Day from './Day.svelte';
@@ -61,7 +61,10 @@
     }));
 
     export function reposition() {
-        height = ceil(max(...runReposition(refs, $_viewDates))) + 10;
+        let payload = getPayload(resource);
+        let resourceLabelHeight = ceil(payload.height ?? 0);
+        let daysRowHeight = ceil(max(...runReposition(refs, $_viewDates)));
+        height = max(resourceLabelHeight, daysRowHeight) + 10;
         $_resHs.set(resource, height);
         $_resHs = $_resHs;
     }

--- a/packages/core/src/plugins/resource-timeline/Label.svelte
+++ b/packages/core/src/plugins/resource-timeline/Label.svelte
@@ -1,12 +1,18 @@
 <script>
     import {getContext, onMount} from 'svelte';
-    import {setContent, toLocalDate, isFunction} from '#lib';
+    import {getPayload, height, setContent, toLocalDate, isFunction} from '#lib';
 
     let {resource, date = undefined} = $props();
 
     let {resourceLabelContent, resourceLabelDidMount} = getContext('state');
 
     let el = $state();
+    let payload = $state.raw({});
+
+    $effect.pre(() => {
+        payload = getPayload(resource);
+    });
+
     // Content
     let content = $derived.by(() => {
         if ($resourceLabelContent) {
@@ -29,6 +35,9 @@
                 el
             });
         }
+
+        let h = el ? height(el) : 0;
+        payload.height = h;
     });
 </script>
 

--- a/packages/core/src/styles/timeline.scss
+++ b/packages/core/src/styles/timeline.scss
@@ -139,9 +139,6 @@
         flex-grow: 0;
         border-bottom: 1px solid var(--ec-border-color);
       }
-      &:last-child {
-        flex-basis: 100%!important;  // for vertical scroll needs
-      }
 
       span {
         padding-top: 8px;


### PR DESCRIPTION
Hi @vkurko.

This will fix issue #401.

Improves resource management by including a height property and refining height calculations in resource timeline components.

<img width="706" height="416" alt="long-content" src="https://github.com/user-attachments/assets/aff6ccb6-f6e8-469b-8862-67ee52721078" />

Closes #401 