### PR TITLE
Adds timezoneOffsetMins option

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -129,6 +129,7 @@ Inspired by [FullCalendar](https://fullcalendar.io/), it implements similar opti
   - [slotWidth](#slotwidth)
   - [snapDuration](#snapduration)
   - [theme](#theme)
+  - [timezoneOffsetMins](#timezoneoffsetmins)
   - [titleFormat](#titleformat)
   - [unselect](#unselect)
   - [unselectAuto](#unselectauto)
@@ -2539,6 +2540,14 @@ function (theme) {
 <td>An object with default CSS classes</td>
 </tr>
 </table>
+
+### timezoneOffsetMins
+- Type `integer`
+- Default `0`
+
+Shifts all displayed times by the given number of minutes. This includes the now indicator, today highlight, and timed event start/end times. All-day events are unaffected.
+
+Use this option to display the calendar in a timezone different from the browser's local time. For example, set `timezoneOffsetMins: 60` to shift all times forward by one hour. Callback functions (e.g. `eventClick`) will receive the offset-adjusted times matching what is displayed.
 
 ### titleFormat
 - Type `object` or `function`

--- a/packages/core/src/lib/date.js
+++ b/packages/core/src/lib/date.js
@@ -117,6 +117,15 @@ export function noTimePart(date) {
 }
 
 /**
+ * Apply a timezone offset in minutes to a date (mutates in place)
+ */
+export function applyOffset(date, offsetMins) {
+    date.setUTCMinutes(date.getUTCMinutes() + offsetMins);
+
+    return date;
+}
+
+/**
  * Copy time from one date to another
  */
 export function copyTime(toDate, fromDate) {

--- a/packages/core/src/lib/events.js
+++ b/packages/core/src/lib/events.js
@@ -1,5 +1,5 @@
 import {
-    addDay, cloneDate, copyTime, createDate, datesEqual, noTimePart, setMidnight, toISOString, toLocalDate
+    addDay, applyOffset, cloneDate, copyTime, createDate, datesEqual, noTimePart, setMidnight, toISOString, toLocalDate
 } from './date.js';
 import {createElement} from './dom.js';
 import {assign, isArray, isFunction} from './utils.js';
@@ -177,4 +177,17 @@ export function ghostEvent(display) {
 
 export function pointerEvent(display) {
     return display === 'pointer';
+}
+
+export function applyTimezoneOffsetToEvents(events, offsetMins) {
+    if (offsetMins) {
+        for (let event of events) {
+            if (!event.allDay) {
+                applyOffset(event.start, offsetMins);
+                applyOffset(event.end, offsetMins);
+            }
+        }
+    }
+
+    return events;
 }

--- a/packages/core/src/storage/effects.js
+++ b/packages/core/src/storage/effects.js
@@ -1,7 +1,7 @@
 import {getAbortSignal, tick, untrack} from 'svelte';
 import {
-    assign, cloneDate, createDate, createEvents, createResources, datesEqual, empty, isArray, isFunction, setMidnight,
-    toISOString, toLocalDate, toViewWithLocalDates
+    applyOffset, applyTimezoneOffsetToEvents, assign, cloneDate, createDate, createEvents, createResources, datesEqual,
+    empty, isArray, isFunction, setMidnight, toISOString, toLocalDate, toViewWithLocalDates
 } from '#lib';
 import {arrayProxy} from './proxy.svelte.js';
 
@@ -23,14 +23,14 @@ export function loadEvents(mainState, loadingInvoker) {
     return () => {
         // Dependencies
         let {activeRange, fetchedRange: {events: fetchedRange}, viewDates,
-            options: {events, eventSources, lazyFetching}} = mainState;
+            options: {events, eventSources, lazyFetching, timezoneOffsetMins}} = mainState;
 
         untrack(() => {
             load(
                 eventSources.map(source => isFunction(source.events) ? source.events : source),
                 events,
                 createEvents,
-                result => mainState.events = arrayProxy(result),
+                result => mainState.events = arrayProxy(applyTimezoneOffsetToEvents(result, timezoneOffsetMins)),
                 activeRange,
                 fetchedRange,
                 viewDates,
@@ -155,9 +155,12 @@ export function createLoadingInvoker(mainState) {
 
 export function setNowAndToday(mainState) {
     return () => {
+        // Dependencies
+        let {options: {timezoneOffsetMins}} = mainState;
+
         // Now and today
         let interval = setInterval(() => {
-            let now = createDate();
+            let now = applyOffset(createDate(), timezoneOffsetMins);
             let today = setMidnight(cloneDate(now));
             mainState.now = now;
             if (!datesEqual(mainState.today, today)) {

--- a/packages/core/src/storage/options.js
+++ b/packages/core/src/storage/options.js
@@ -91,6 +91,7 @@ function createOptions(plugins) {
             view: '',
             weekdays: ['ec-sun', 'ec-mon', 'ec-tue', 'ec-wed', 'ec-thu', 'ec-fri', 'ec-sat'],
         },
+        timezoneOffsetMins: 0,
         titleFormat: {
             year: 'numeric',
             month: 'short',

--- a/packages/core/src/storage/state.svelte.js
+++ b/packages/core/src/storage/state.svelte.js
@@ -1,5 +1,5 @@
 import {SvelteMap} from 'svelte/reactivity';
-import {createDate, identity, intl, intlRange, setMidnight} from '#lib';
+import {applyOffset, createDate, identity, intl, intlRange, setMidnight} from '#lib';
 import {optionsState} from './options.js';
 import {
     createLoadingInvoker, loadEvents, loadResources, runDatesSet, runEventAllUpdated, runViewDidMount, setNowAndToday,
@@ -26,9 +26,9 @@ export default class State {
         this.events = $state.raw(arrayProxy(this.options.events));
         this.filteredEvents = $derived.by(filteredEvents(this));
         this.mainEl = $state();
-        this.now = $state(createDate());
+        this.now = $state(applyOffset(createDate(), this.options.timezoneOffsetMins));
         this.resources = $state.raw(arrayProxy(this.options.resources));
-        this.today = $state(setMidnight(createDate()));
+        this.today = $state(setMidnight(applyOffset(createDate(), this.options.timezoneOffsetMins)));
         this.intlEventTime = $derived.by(intlRange(this, 'eventTimeFormat'));
         this.intlDayHeader = $derived.by(intl(this, 'dayHeaderFormat'));
         this.intlDayHeaderAL = $derived.by(intl(this, 'dayHeaderAriaLabelFormat'));


### PR DESCRIPTION
There has a been a couple issues asking about timezone support and I see you don't want to add it until Temporal support. Someone had suggested in the title of their issue (https://github.com/vkurko/calendar/issues/576) to add some way of offsetting the time calculations so that we can just manually supply the timezone offset. I think this PR will solve it and adds barely any code so keeps the library night and lightweight.

Users will have to calculate the browser time and the desired timzone and diff the number of minutes but that should be easy in most cases.

Our use case is customers may have buildings they want to see lighting schedules for all around the world and it should display the schedules in the timezone of the building they are looking at.