### PR TITLE
feat: adding beforeResourceExpand option

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Inspired by [FullCalendar](https://fullcalendar.io/), it implements similar opti
 
   - [allDayContent](#alldaycontent)
   - [allDaySlot](#alldayslot)
+  - [beforeResourceExpand](#beforeResourceExpand)
   - [buttonText](#buttontext)
   - [columnWidth](#columnwidth)
   - [customButtons](#custombuttons)
@@ -346,6 +347,48 @@ The default text
 Determines whether the `all-day` slot is displayed at the top of the calendar.
 
 When hidden with `false`, all-day events will not be displayed in `timeGrid`/`resourceTimeGrid` views.
+
+### beforeResourceExpand
+- Type `function`
+- Default `undefined`
+
+Callback function that is triggered before a resource with nested children is expanded or collapsed in `resourceTimeline` views.
+
+
+```js
+function (info) { }
+```
+`info` is an object with the following properties:
+<table>
+<tr>
+<td>
+
+`resource`
+</td>
+<td>
+
+The associated [Resource](#resource-object) object
+</td>
+</tr>
+<tr>
+<td>
+
+`jsEvent`
+</td>
+<td>JavaScript native event object with low-level information such as click coordinates</td>
+</tr>
+<tr>
+<td>
+
+`view`
+</td>
+<td>
+
+The current [View](#view-object) object
+</td>
+</tr>
+</table>
+
 
 ### buttonText
 - Type `object` or `function`

--- a/packages/build/README.md
+++ b/packages/build/README.md
@@ -42,6 +42,7 @@ Inspired by [FullCalendar](https://fullcalendar.io/), it implements similar opti
 
   - [allDayContent](#alldaycontent)
   - [allDaySlot](#alldayslot)
+  - [beforeResourceExpand](#beforeResourceExpand)
   - [buttonText](#buttontext)
   - [columnWidth](#columnwidth)
   - [customButtons](#custombuttons)
@@ -346,6 +347,48 @@ The default text
 Determines whether the `all-day` slot is displayed at the top of the calendar.
 
 When hidden with `false`, all-day events will not be displayed in `timeGrid`/`resourceTimeGrid` views.
+
+### beforeResourceExpand
+- Type `function`
+- Default `undefined`
+
+Callback function that is triggered before a resource with nested children is expanded or collapsed in `resourceTimeline` views.
+
+
+```js
+function (info) { }
+```
+`info` is an object with the following properties:
+<table>
+<tr>
+<td>
+
+`resource`
+</td>
+<td>
+
+The associated [Resource](#resource-object) object
+</td>
+</tr>
+<tr>
+<td>
+
+`jsEvent`
+</td>
+<td>JavaScript native event object with low-level information such as click coordinates</td>
+</tr>
+<tr>
+<td>
+
+`view`
+</td>
+<td>
+
+The current [View](#view-object) object
+</td>
+</tr>
+</table>
+
 
 ### buttonText
 - Type `object` or `function`

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -42,6 +42,7 @@ Inspired by [FullCalendar](https://fullcalendar.io/), it implements similar opti
 
   - [allDayContent](#alldaycontent)
   - [allDaySlot](#alldayslot)
+  - [beforeResourceExpand](#beforeResourceExpand)
   - [buttonText](#buttontext)
   - [columnWidth](#columnwidth)
   - [customButtons](#custombuttons)
@@ -346,6 +347,48 @@ The default text
 Determines whether the `all-day` slot is displayed at the top of the calendar.
 
 When hidden with `false`, all-day events will not be displayed in `timeGrid`/`resourceTimeGrid` views.
+
+### beforeResourceExpand
+- Type `function`
+- Default `undefined`
+
+Callback function that is triggered before a resource with nested children is expanded or collapsed in `resourceTimeline` views.
+
+
+```js
+function (info) { }
+```
+`info` is an object with the following properties:
+<table>
+<tr>
+<td>
+
+`resource`
+</td>
+<td>
+
+The associated [Resource](#resource-object) object
+</td>
+</tr>
+<tr>
+<td>
+
+`jsEvent`
+</td>
+<td>JavaScript native event object with low-level information such as click coordinates</td>
+</tr>
+<tr>
+<td>
+
+`view`
+</td>
+<td>
+
+The current [View](#view-object) object
+</td>
+</tr>
+</table>
+
 
 ### buttonText
 - Type `object` or `function`

--- a/packages/core/src/plugins/resource-timeline/Expander.svelte
+++ b/packages/core/src/plugins/resource-timeline/Expander.svelte
@@ -4,7 +4,7 @@
 
     let {resource} = $props();
 
-    let {resources, view, options: {buttonText, icons, resourceExpand, theme}} = $derived(getContext('state'));
+    let {resources, view, options: {buttonText, icons, beforeResourceExpand, resourceExpand, theme}} = $derived(getContext('state'));
 
     let payload = $state.raw({});
     let expanded = $derived(resource.expanded);
@@ -15,6 +15,10 @@
     });
 
     function onclick(jsEvent) {
+        if (isFunction(beforeResourceExpand)) {
+            beforeResourceExpand({resource, jsEvent, view: toViewWithLocalDates(view)});
+        }
+
         resource.expanded = expanded = !expanded;
         toggle(payload.children);
         resources.length = resources.length;

--- a/packages/core/src/plugins/resource-timeline/index.js
+++ b/packages/core/src/plugins/resource-timeline/index.js
@@ -12,6 +12,7 @@ export default {
 			monthHeaderFormat: {  // ec option
 				month: 'long'
 			},
+			beforeResourceExpand: undefined, // ec option
 			resourceExpand: undefined,  // ec option
 			slotWidth: 32,  // ec option
 			// Common options


### PR DESCRIPTION
Capability to add callback before resource expand

Why?
For example: if all resources are pre-loaded sometimes it takes time to render expanded resources. This callback will allow to initiate UI loader before it expands