### PR TITLE
Fix empty exports when @event-calendar/build is consumed via CommonJS or ESM

### DIFF
--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -17,6 +17,18 @@
     "directory": "packages/build"
   },
   "license": "MIT",
-  "main": "./dist/event-calendar.min.js",
-  "style": "./dist/event-calendar.min.css"
+  "main": "./dist/event-calendar.min.cjs",
+  "module": "./dist/event-calendar.min.mjs",
+  "unpkg": "./dist/event-calendar.min.js",
+  "jsdelivr": "./dist/event-calendar.min.js",
+  "style": "./dist/event-calendar.min.css",
+  "exports": {
+    ".": {
+      "import": "./dist/event-calendar.min.mjs",
+      "require": "./dist/event-calendar.min.cjs",
+      "default": "./dist/event-calendar.min.js"
+    },
+    "./event-calendar.min.css": "./dist/event-calendar.min.css",
+    "./package.json": "./package.json"
+  }
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -15,8 +15,13 @@ export default defineConfig(({command, mode, isSsrBuild, isPreview}) => {
                 lib: {
                     name: 'EventCalendar',
                     entry: ['packages/core/src/index.iife.js'],
-                    fileName: () => 'event-calendar.min.js',
-                    formats: ['iife'],
+                    fileName: format => {
+                        if (format === 'iife') return 'event-calendar.min.js';
+                        if (format === 'es') return 'event-calendar.min.mjs';
+                        if (format === 'cjs') return 'event-calendar.min.cjs';
+                        return `event-calendar.min.${format}.js`;
+                    },
+                    formats: ['iife', 'es', 'cjs'],
                     cssFileName: 'event-calendar.min',
                 },
                 outDir: 'packages/build/dist',


### PR DESCRIPTION
## Summary

- `@event-calendar/build` only ships an IIFE bundle (`event-calendar.min.js`), which attaches `window.EventCalendar` but has no module exports.
- Bundlers that only resolve CommonJS / ESM — JSPM, esbuild, and similar — therefore see an empty default export when they `import` or `require` the package. Example of the bug:
  ```js
  import ec from '@event-calendar/build';
  // ec === {} — there is nothing to export from an IIFE
  ```
- This PR emits ESM (`.mjs`) and CJS (`.cjs`) variants alongside the IIFE bundle and wires them through `package.json#exports`. Script-tag users are unaffected.

## Changes

- `vite.config.js`: the `iife` mode now builds `['iife', 'es', 'cjs']`, producing `event-calendar.min.js`, `event-calendar.min.mjs` and `event-calendar.min.cjs` (shared CSS).
- `packages/build/package.json`:
  - Add `exports` with `import` / `require` / `default` conditions.
  - Add `module`, `unpkg`, `jsdelivr` fields.
  - Point `main` at the CJS bundle.
- Svelte is still bundled in for all three formats — the build package stays self-contained. The IIFE global name, filename and content are unchanged, so existing `<script src="…/event-calendar.min.js">` usage (unpkg, jsdelivr, docs) keeps working.

## Verification

After `npm run build`, `packages/build/dist/` contains:

```
event-calendar.min.js    (IIFE, minified, existing file — unchanged in shape)
event-calendar.min.mjs   (ESM)
event-calendar.min.cjs   (CJS)
event-calendar.min.css
```

Resolved through `@event-calendar/build`:

```js
import { create, destroy } from '@event-calendar/build';     // → { create, destroy }
const { create, destroy } = require('@event-calendar/build'); // → { create, destroy }
```

Both return real functions instead of an empty object. Verified end-to-end through Node's `exports` resolution.

## Test plan

- [ ] `npm run build` produces `.js`, `.mjs`, `.cjs` + `.css` in `packages/build/dist/`
- [ ] `import` from `@event-calendar/build` returns `{ create, destroy }`
- [ ] `require` of `@event-calendar/build` returns `{ create, destroy }`
- [ ] `window.EventCalendar.create(...)` still works for CDN script-tag consumers
- [ ] jsdelivr / unpkg URLs in the README keep resolving to the IIFE bundle