### PR TITLE
Guard resource label innerText access against destroyed element

### DIFF
--- a/packages/core/src/plugins/resource-time-grid/Label.svelte
+++ b/packages/core/src/plugins/resource-time-grid/Label.svelte
@@ -27,10 +27,10 @@
         untrack(() => {
             // Accessing innerText after tick significantly improves performance
             if (date) {
-                tick().then(() => ariaLabel = intlDayHeaderAL.format(date) + ', ' + el.innerText);
+                tick().then(() => el && (ariaLabel = intlDayHeaderAL.format(date) + ', ' + el.innerText));
             } else if (setLabel) {
                 ariaLabel = undefined;
-                tick().then(() => setLabel(el.innerText));
+                tick().then(() => el && setLabel(el.innerText));
             }
         });
     });


### PR DESCRIPTION
Fixes #653.

When a resource is removed from `resources` while `resourceTimeGridDay` is active, the `Label` component is destroyed in the same flush and `bind:this` resets `el` to `null`. The `tick().then(...)` callback scheduled by the aria-label effect still runs afterwards and reads `el.innerText`, throwing `Cannot read properties of null (reading 'innerText')` as an unhandled rejection.

Guarded both `innerText` reads with a check that `el` still exists so the queued callback is a no-op once the element is gone. No behavior change when the element is present.
